### PR TITLE
KeyError at line 18, Changed 'Content-Type' to 'content-type'

### DIFF
--- a/lambda/lambda_api_multipart.py
+++ b/lambda/lambda_api_multipart.py
@@ -15,7 +15,7 @@ def lambda_handler(event, context):
     # decoding form-data into bytes
     post_data = base64.b64decode(event['body'])
     # fetching content-type
-    content_type = event["headers"]['Content-Type']
+    content_type = event["headers"]['content-type']
     # concate Content-Type: with content_type from event
     ct = "Content-Type: "+content_type+"\n"
 


### PR DESCRIPTION
## CloudWatchLog is showing KeyError, as follows:

#### **[ERROR] KeyError: 'Content-Type'Traceback (most recent call last):  File "/var/task/lambda_function.py", line 13, in lambda_handler    content_type = event["headers"]['Content-Type']**

After print(event) , I noticed that it should be 'content-type' not 'Content-Type'.

_Great tutorial on API Gateway on Youtube. Love it._